### PR TITLE
Avoid SIGNING_SECRET check for PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,8 +52,10 @@ jobs:
 
       # Confirm that cosign.pub matches SIGNING_SECRET
       - uses: sigstore/cosign-installer@v3.2.0
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/live'
 
       - name: Check SIGNING_SECRET matches cosign.pub
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/live'
         shell: bash
         run: |
           diff -u <(cosign public-key --key env://COSIGN_PRIVATE_KEY) cosign.pub


### PR DESCRIPTION
External PRs (e.g. from dependabot) don't have access to secrets.